### PR TITLE
Route to unanswered if no voting round

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem "acts-as-taggable-on", "~> 2.4.1"
 gem 'bootstrap-sass', '~> 3.0.3.0'
 gem 'bcrypt-ruby', '~> 3.0.0'
 gem "email_validator", "~> 1.4.0"
-gem 'flickraw' 
+gem 'flickraw'
 
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 1.2'
@@ -38,6 +38,7 @@ gem 'will_paginate', '~> 3.0'
 #gem 'coffee-rails', '~> 4.0.0'
 
 group :development, :test do
+  gem 'test-unit'
   gem 'rspec-rails', '~> 2.0'
   gem 'shoulda', '~> 3.5.0'
   gem 'factory_girl_rails', '~>4.2.1'
@@ -49,7 +50,6 @@ group :development, :test do
   gem "launchy"
   gem "selenium-webdriver"
   gem "database_cleaner", '~> 1.2.0'
-  gem 'debugger'
 end
 
 group :doc do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,14 +51,7 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.7.1)
-    columnize (0.8.9)
     database_cleaner (1.2.0)
-    debugger (1.6.8)
-      columnize (>= 0.3.1)
-      debugger-linecache (~> 1.2.0)
-      debugger-ruby_core_source (~> 1.3.5)
-    debugger-linecache (1.2.0)
-    debugger-ruby_core_source (1.3.5)
     diff-lcs (1.2.5)
     email_validator (1.4.0)
       activemodel
@@ -107,6 +100,7 @@ GEM
       mini_portile (= 0.6.0)
     phantomjs (1.9.7.1)
     polyglot (0.3.5)
+    power_assert (0.2.2)
     rack (1.5.2)
     rack-test (0.6.2)
       rack (>= 1.0)
@@ -183,6 +177,8 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (~> 2.8)
+    test-unit (3.0.8)
+      power_assert
     therubyracer (0.12.0)
       libv8 (~> 3.16.14.0)
       ref
@@ -218,7 +214,6 @@ DEPENDENCIES
   bootstrap-sass (~> 3.0.3.0)
   capybara (~> 2.1.0, < 3.0)
   database_cleaner (~> 1.2.0)
-  debugger
   email_validator (~> 1.4.0)
   factory_girl_rails (~> 4.2.1)
   flickraw
@@ -237,6 +232,7 @@ DEPENDENCIES
   selenium-webdriver
   shoulda (~> 3.5.0)
   site_prism (~> 2.4)
+  test-unit
   therubyracer (= 0.12.0)
   turbolinks
   uglifier (>= 1.3.0)

--- a/app/assets/stylesheets/modules/_colors.scss
+++ b/app/assets/stylesheets/modules/_colors.scss
@@ -1,0 +1,9 @@
+$nice-blue: #03bef5;
+$hot-pink: #ff0066;
+$bold-blue: #00bff3;
+$light_nice_blue: #3dcef6;
+$purple: #662d91;
+$blue: #6dcff6;
+$light-blue: #91d8f6;
+$light-green: #00FF00;
+

--- a/app/assets/stylesheets/partials/_alerts.scss
+++ b/app/assets/stylesheets/partials/_alerts.scss
@@ -1,0 +1,8 @@
+@import "modules/colors";
+@import "modules/all";
+.alert.alert-banner-message {
+  color: black;
+  text-align: center;
+  border: hot-pink-border();
+  margin: 5px;
+}

--- a/app/assets/stylesheets/partials/_base.scss
+++ b/app/assets/stylesheets/partials/_base.scss
@@ -8,17 +8,9 @@ Curious City is distributed in the hope that it will be useful, but WITHOUT ANY 
 
 You should have received a copy of the GNU General Public License along with Curious City.  If not, see <http://www.gnu.org/licenses/>.
 */
+@import "modules/colors";
 @import "modules/all";
 @import "modules/common_features";
-$nice-blue: #03bef5;
-$hot-pink: #ff0066; 
-$bold-blue: #00bff3;
-$light_nice_blue: #3dcef6;
-$purple: #662d91;
-$blue: #6dcff6;
-$light-blue: #91d8f6;
-$light-green: #00FF00;
-
 $grid-unit: 16px;
 
 $crowded-room: 2%;
@@ -43,7 +35,7 @@ $mobile-max-width: 767px;
 }
 .little-writing {
   font-weight: normal;
-  font-size: 10px; 
+  font-size: 10px;
 }
 
 .no-changing {
@@ -54,7 +46,7 @@ $mobile-max-width: 767px;
   position: relative;
   padding: $grid-unit;
   padding-right: 0;
-  
+
   .carrot {
     position: absolute;
     top: 40%;
@@ -126,7 +118,7 @@ $mobile-max-width: 767px;
   display: inline;
   * {
     word-wrap: break-word;
-    margin: $grid-unit 0; 
+    margin: $grid-unit 0;
   }
   h4 {
     font-size: $grid-unit * 2;
@@ -197,14 +189,14 @@ a {
 
 @media (max-width: $mobile-max-width) {
   .container-padding {
-    padding: $container-padding / 4; 
+    padding: $container-padding / 4;
   }
   .submit-question-text {
     font-size: $grid-unit * .75;
   }
   .response-text {
     * {
-      margin: $grid-unit * .75 0; 
+      margin: $grid-unit * .75 0;
     }
     h4 {
       font-size: $grid-unit * 1.5;

--- a/app/controllers/voting_rounds_controller.rb
+++ b/app/controllers/voting_rounds_controller.rb
@@ -21,7 +21,7 @@ class VotingRoundsController < ApplicationController
     if @voting_round
       @previous_voting_round = @voting_round.previous
     else
-      redirect_to filter_questions_url(status: "answered"), notice: "We currently aren't running a voting round. Check out the questions we've already answered!"
+      redirect_to filter_questions_url(status: "answered"), flash: {"banner-message" => "We currently aren't running a voting round. Check out the questions we've already answered!"}
     end
   end
 

--- a/app/controllers/voting_rounds_controller.rb
+++ b/app/controllers/voting_rounds_controller.rb
@@ -21,7 +21,7 @@ class VotingRoundsController < ApplicationController
     if @voting_round
       @previous_voting_round = @voting_round.previous
     else
-      redirect_to filter_questions_url(status: "answered"), flash: {"banner-message" => "We currently aren't running a voting round. Check out the questions we've already answered!"}
+      redirect_to filter_questions_url(status: "answered"), flash: {"banner-message" => "We currently aren't running a voting round. In the meantime, check out the questions we've already answered!"}
     end
   end
 

--- a/app/controllers/voting_rounds_controller.rb
+++ b/app/controllers/voting_rounds_controller.rb
@@ -17,7 +17,12 @@ class VotingRoundsController < ApplicationController
   def home
     @up_for_voting_class = "highlighted"
     @voting_round = VotingRound.where(status: VotingRound::Status::Live).first
-    @previous_voting_round = @voting_round.previous unless @voting_round.nil?
+
+    if @voting_round
+      @previous_voting_round = @voting_round.previous
+    else
+      redirect_to filter_questions_url(status: "answered")
+    end
   end
 
   def about

--- a/app/controllers/voting_rounds_controller.rb
+++ b/app/controllers/voting_rounds_controller.rb
@@ -21,7 +21,7 @@ class VotingRoundsController < ApplicationController
     if @voting_round
       @previous_voting_round = @voting_round.previous
     else
-      redirect_to filter_questions_url(status: "answered")
+      redirect_to filter_questions_url(status: "answered"), notice: "We currently aren't running a voting round. Check out the questions we've already answered!"
     end
   end
 

--- a/spec/controllers/voting_rounds_controller_spec.rb
+++ b/spec/controllers/voting_rounds_controller_spec.rb
@@ -13,29 +13,41 @@ require 'spec_helper'
 describe VotingRoundsController do
 
   describe "GET home" do
-    before do
-      @voting_round = double(:voting_round)
-      VotingRound.stub(:where).with(status: VotingRound::Status::Live).and_return([@voting_round])
-      @prev_voting_round = double(:voting_round)
-      @voting_round.stub(:previous).and_return(@prev_voting_round)
-      subject.stub(:load_categories)
+    context "When there is a voting round live" do
+      before do
+        @voting_round = double(:voting_round)
+        VotingRound.stub(:where).with(status: VotingRound::Status::Live).and_return([@voting_round])
+        @prev_voting_round = double(:voting_round)
+        @voting_round.stub(:previous).and_return(@prev_voting_round)
+        subject.stub(:load_categories)
+      end
+
+      it "loads the categories" do
+        subject.should_receive(:load_categories)
+        get :home, {}, {}
+      end
+
+      it "assigns active voting round" do
+        get :home, {}, {}
+        assigns(:voting_round).should eq @voting_round
+      end
+
+      it "assigns past voting round" do
+        get :home, {}, {}
+        assigns(:previous_voting_round).should eq @prev_voting_round
+      end
     end
 
-    it "loads the categories" do
-      subject.should_receive(:load_categories)
-      get :home, {}, {}
-    end
-
-    it "assigns active voting round" do
-      get :home, {}, {}
-      assigns(:voting_round).should eq @voting_round
-    end
-
-    it "assigns past voting round" do
-      get :home, {}, {}
-      assigns(:previous_voting_round).should eq @prev_voting_round
+    context "when there is no live voting round" do
+      it "redirects to the 'under investigation' page" do
+        VotingRound.stub(:where).with(status: VotingRound::Status::Live).and_return([])
+        subject.stub(:load_categories)
+        get :home, {}, {}
+        response.should redirect_to(filter_questions_url(status: "answered"))
+      end
     end
   end
+
   describe "GET about" do
     it "assigns @about_class to highlighted" do
       get :about, {}, {}

--- a/spec/controllers/voting_rounds_controller_spec.rb
+++ b/spec/controllers/voting_rounds_controller_spec.rb
@@ -46,6 +46,15 @@ describe VotingRoundsController do
         response.should redirect_to(filter_questions_url(status: "answered"))
       end
     end
+
+    context "when there is no live voting round" do
+      it "redirects to the 'under investigation' page" do
+        VotingRound.stub(:where).with(status: VotingRound::Status::Live).and_return([])
+        subject.stub(:load_categories)
+        get :home, {}, {}
+        response.should redirect_to(filter_questions_url(status: "answered"))
+      end
+    end
   end
 
   describe "GET about" do

--- a/spec/controllers/voting_rounds_controller_spec.rb
+++ b/spec/controllers/voting_rounds_controller_spec.rb
@@ -52,7 +52,7 @@ describe VotingRoundsController do
         VotingRound.stub(:where).with(status: VotingRound::Status::Live).and_return([])
         subject.stub(:load_categories)
         get :home, {}, {}
-        response.should redirect_to(filter_questions_url(status: "answered"))
+        expect(response).to redirect_to(filter_questions_url(status: "answered"))
       end
     end
   end


### PR DESCRIPTION
This is a change, based on Mark Brush's request, to change the behavior when there is no active voting round. Instead of showing a blank voting round page, redirect the user to the "Answered and Investing" page to highlight that there is a lot of content that can be perused. Since MICurious run voting rounds once a month, this is a significant issue for the times when a voting round isn't happening.
